### PR TITLE
Update decla_lu.ejs

### DIFF
--- a/src/tpl/decla_lu.ejs
+++ b/src/tpl/decla_lu.ejs
@@ -260,6 +260,6 @@
         Am Fall, wou d’Äntwert net befriddegend wier, hutt Dir d’Méiglechkeet, den <a href="https://sip.gouvernement.lu">Informatiouns- a Pressedéngscht</a>, dee fir d’Kontroll vun der Accessibilitéit zoustänneg ass, iwwer säin <a href="https://sip.gouvernement.lu/lb/support/reclamation-accessibilite.html">Online-Reklamatiounsformulaire</a> oder <a href="https://www.ombudsman.lu/">d’Ombudspersoun</a>, de Mediateur vum Groussherzogtum Lëtzebuerg, ze informéieren.
     </p>
     <hr />
-    <p><small>Dës Deklaratioun baséiert op der Virlag vum Dokument, dat an der <a href="https://eur-lex.europa.eu/legal-content/FR/TXT/?uri=CELEX%3A32018D1523" hreflang="fr">Ausféierungsdecisioun (EU) 2018/1523</a> definéiert ass. Dës Virlag gehéiert der Europäescher Unioun a gëtt ënner enger <a href="https://creativecommons.org/licenses/by/4.0/" lang="en" hreflang="en">"Creative Commons Attribution 4.0 International"-Lizenz</a> verëffentlecht.</small></p>
+    <p><small>Dës Deklaratioun baséiert op der Virlag vum Dokument, dat an der <a href="https://eur-lex.europa.eu/legal-content/FR/TXT/?uri=CELEX%3A32018D1523" hreflang="fr">Ausféierungsdecisioun (EU) 2018/1523</a> definéiert ass. Dës Virlag gehéiert der Europäescher Unioun a gëtt ënner enger <a href="https://creativecommons.org/licenses/by/4.0/" lang="en" hreflang="en">Creative Commons Attribution 4.0 International</a> Lizenz verëffentlecht.</small></p>
     </div>
     


### PR DESCRIPTION
Implements coherence of linked text between languages, as others don't include 'license' in the link
Fixes language tag mismatch, as 'Lizenz' is not english